### PR TITLE
feat(user): add update user endpoint with avatar support

### DIFF
--- a/simpleform/internal/routes/routes.go
+++ b/simpleform/internal/routes/routes.go
@@ -11,5 +11,6 @@ func Route(app *fiber.App) {
 	route.Post("/", handlers.AddUser)
 	route.Get("/all", handlers.ReadUsers)
 	route.Get("/:id", handlers.ReadOneUser)
+	route.Put("/:id", handlers.UpdateUser)
 	route.Delete("/:id", handlers.DeleteUser)
 }


### PR DESCRIPTION
Implement PUT /:id endpoint to update user details including email, city and avatar. The handler processes multipart form data, uploads avatar files, and updates the user record in MongoDB. Also fixes response format consistency in DeleteUser endpoint.