### PR TITLE
feat: add websocket server and client for message length counting

### DIFF
--- a/go-web-socket/go.mod
+++ b/go-web-socket/go.mod
@@ -1,0 +1,5 @@
+module go-web-socket
+
+go 1.24.3
+
+require golang.org/x/net v0.41.0 // indirect

--- a/go-web-socket/go.sum
+++ b/go-web-socket/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=

--- a/go-web-socket/index.html
+++ b/go-web-socket/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Test</title>
+
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+</head>
+<style>
+	.text-area {
+		text-align: center;
+	}
+</style>
+
+<body>
+
+	<script>
+		//initially undefined; the variable holds the WebSocket connection object.
+		var socket;
+
+
+		function update(msg) {
+			$('#messageArea').html(msg)
+		}
+
+		function connectWS() {
+			var host = "ws://localhost:4321/length"
+
+			//creates a new WebSocket connection to the specified host
+			socket = new WebSocket(host);
+
+			//the event listener triggers when the connection opened and displays message
+			socket.onopen = function () {
+				update("Websocket connected")
+			}
+
+			//the event listener is triggered when a message is received from a server
+			socket.onmessage = function (message) {
+
+				//the event trigger is triggered when a message is received from the server
+				//and calls the `update` function to display the character count from the server
+				update('Websocket counted ' + message.data + ' characters in your message')
+			}
+			socket.onclose = function () {
+				update('Websocket closed')
+			}
+		}
+
+		function send() {
+			socket.send($('#message').val());
+		}
+		function closeSocket() {
+			socket.close();
+		}
+
+		//this initiates the connection and processes as soon as the script loads.
+		connectWS();
+	</script>
+
+	<div class="text-area">
+		<h2>Message:</h2>
+		<textarea id="message" style="width:50%;height:300px;font-size:20px;"></textarea>
+		<div>
+
+			<!-- submit button that triggers the send function; sending the message to the server -->
+			<input type="submit" value="Send" onclick="send()" />
+
+			<!-- Closes the WebSocket connection -->
+			<input type="button" onclick="closeSocket();" value="Close">
+		</div>
+	</div>
+
+	<div id="messageArea"></div>
+
+</body>
+
+</html>

--- a/go-web-socket/main.go
+++ b/go-web-socket/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"golang.org/x/net/websocket"
+)
+
+// the server will listen for incoming connections on this port
+var address = ":4321"
+
+// takes a pointer to a `websocket.Conn` object as input.
+// This object represents the established connection with the client
+func LengthServerResponse(ws *websocket.Conn) {
+
+	//this variable stores messages received from the client
+	var msg string
+
+	// this keeps running as long as the connection is open.
+	// what determines an open connection ?
+
+	for {
+		//we receive the message from the client and store in `msg`
+		websocket.Message.Receive(ws, &msg)
+		fmt.Println("msg got", msg)
+
+		//calculates the length of the received message
+		msgLen := len(msg)
+
+		//converts int length to string, sens the string back through established websocket connection
+		//checks for errors while processing
+
+		if err := websocket.Message.Send(ws, strconv.FormatInt(int64(msgLen), 10)); err != nil {
+			fmt.Println("cannot send message length")
+			break
+		}
+	}
+}
+
+func websocketListen() {
+	//when a client connects to the `/length` path, the `websocket.Handler` uses
+	//the logic in function created earlier to handle WebSocket communication.
+	http.Handle("/length", websocket.Handler(LengthServerResponse))
+	err := http.ListenAndServe(address, nil)
+	if err != nil {
+		panic("ListenAndServe: " + err.Error())
+	}
+}
+
+func main() {
+	http.HandleFunc("/websocket", func(w http.ResponseWriter, r *http.Request) {
+		//this serves the html file to the client as a response to `/websocket` request
+		http.ServeFile(w, r, "index.html")
+	})
+	websocketListen()
+}


### PR DESCRIPTION
Implement a Go websocket server that counts message length and returns it to the client. Add HTML client interface to connect, send messages and display length responses. Initialize Go module with required dependencies.